### PR TITLE
Add Tanh activation

### DIFF
--- a/src/neural_network/activations.py
+++ b/src/neural_network/activations.py
@@ -3,3 +3,7 @@ import numpy as np
 
 def sigmoid(x):
     return 1 / (1 + np.exp(-x))
+
+
+def tanh(x):
+    return np.tanh(x)

--- a/tests/test_activations.py
+++ b/tests/test_activations.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from neural_network.activations import sigmoid
+from neural_network.activations import sigmoid, tanh
 
 
 # Test sigmoid function with scalar input
@@ -22,3 +22,24 @@ def test_sigmoid_array():
 def test_sigmoid_output_range():
     for x in np.linspace(-10, 10, 100):
         assert 0 <= sigmoid(x) <= 1
+
+
+# Test tanh function with scalar input
+def test_tanh_scalar():
+    assert tanh(0) == 0
+    assert tanh(100) > 0.99
+    assert tanh(-100) < -0.99
+
+
+# Test tanh function with numpy array input
+def test_tanh_array():
+    input_array = np.array([-1, 0, 1])
+    output_array = tanh(input_array)
+    expected_output = np.array([np.tanh(-1), np.tanh(0), np.tanh(1)])
+    assert np.allclose(output_array, expected_output)
+
+
+# Test tanh output range
+def test_tanh_output_range():
+    for x in np.linspace(-10, 10, 100):
+        assert -1 <= tanh(x) <= 1


### PR DESCRIPTION
This PR contains code to calculate the tanh activation function. It's a simple alias around `np.tanh`.

This will be useful when trying out different model configurations. I've added some basic functionality checks in the test suite under `test_activations.py`.

Resolves #4.